### PR TITLE
Add minimal metadata to be able to pip install and import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+
+[project]
+name = "DynamicRoutingTask"
+version = "0.1.0"
+dependencies = [
+    "h5py",
+    "numpy",
+    "pandas",
+    "scipy",
+    "matplotlib",
+]
+requires-python = ">=3.9"
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["Analysis"]  # package names should match these glob patterns (["*"] by default)


### PR DESCRIPTION
This should be enough to either:
 - clone the repo and `pip install -e .`
- or `pip install git+https://github.com/samgale/DynamicRoutingTask`

Modules in the Analysis folder can then be imported:
`from Analysis.DynamicRoutingAnalysisUtils import DynRoutData`