### PR TITLE
Add packaging workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+# This workflow will install Python dependencies, run tests and lint/formatting - possibly with a variety of Python versions - bump version, re-commit  publish to PYPI
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Publish Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+      
+jobs:
+  package:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.9"]
+    permissions: write-all
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        
+    - uses: pdm-project/setup-pdm@v3
+      with:
+        version: 'head' 
+        
+    - name: Install packaging dependencies
+      run: |
+        pip install "pdm-bump>=0.7.3"
+        
+    - name: Bump project version
+      run: |
+        pdm bump micro
+
+    - name: Publish
+      run: |
+        pdm publish
+        
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        message: "Bump [skip actions]"
+        
+    - name: Tag commit
+      run: |
+        pdm bump tag
+        git push --tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,162 @@
-*.pyc
-**/__pycache__/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.package-dir]
 DynamicRoutingTask = "."
-"DynamicRoutingTask.Analysis" = "Analysis"
-"DynamicRoutingTask.OptoGui" = "OptoGui"
-"DynamicRoutingTask.SamStimGui" = "SamStimGui"
 
 [tool.pdm.dev-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,23 @@ dependencies = [
     "matplotlib",
 ]
 requires-python = ">=3.9"
+description = ""
+authors = [
+    {name = "samgale",email = "samg@alleninstitute.org"},
+]
+license = {text = "MIT"}
 
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.packages.find]
-include = ["Analysis"]  # package names should match these glob patterns (["*"] by default)
+[tool.setuptools.package-dir]
+DynamicRoutingTask = "."
+"DynamicRoutingTask.Analysis" = "Analysis"
+"DynamicRoutingTask.OptoGui" = "OptoGui"
+"DynamicRoutingTask.SamStimGui" = "SamStimGui"
+
+[tool.pdm.dev-dependencies]
+dev = [
+    "pdm-bump>=0.7.3",
+]


### PR DESCRIPTION
On each new commit to `main`, a github "Action" will run in a virtual machine, executing the workflow defined in `.github/workflows/publish.yml`:
- the version number will be incremented in `pyproject.toml` (required for publishing a new version)
- the package will be published (https://pypi.org/project/DynamicRoutingTask/)
- if successful, a commit with the modified `pyproject.toml` + tagged with the new version number will be pushed back to the repo
- if a new commit to `main` occurs while the workflow is underway, the previous run will be cancelled and a new one started with the most recent commit

_This will probably require changing the following settings on the repo to give permissions to github's bots:_
![image](https://github.com/samgale/DynamicRoutingTask/assets/63425812/9f8a1fb1-756d-4a3c-a9e9-f4fad73b18da)

Thanks!